### PR TITLE
Skips 2FA check when secret not set

### DIFF
--- a/classes/eventlisteners/backend/UserLogin.php
+++ b/classes/eventlisteners/backend/UserLogin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Adrenth\Security\Classes\EventListeners\Backend;
 
 use Backend;
+use BackendAuth;
 
 /**
  * Class UserLogin
@@ -15,6 +16,12 @@ class UserLogin
 {
     public function handle()
     {
+        $user = BackendAuth::getUser();
+
+        if (empty($user->getAttribute('google2fa_secret'))) {
+            return;
+        }
+        
         Backend::redirect('adrenth/security/twofactor/verify')->send();
     }
 }


### PR DESCRIPTION
When user logs in for the first time (without setting 2FA yet) it needs to skip the verification page.